### PR TITLE
Working master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,24 @@ Quick Start
 -----------
 Just `docker-compose up`
 
+If you want a Cloud9 environment: `git checkout 239e5da`
+
 Prerequisites and Assumptions
 -----------------------------
-- Install [Docker for Mac](https://www.docker.com/products/docker#/mac) (or windows if you're into that sort thing)
-- This assumes a *nix like environment, meaning you need:
-    - SSH set up on your host at `~/.ssh` with a `id_rsa` that is not password protected (for now)
-    - A `.gitconfig` in `~/.gitconfig`
-- *NOTE* This currently assumes you pull this down into `./dev`.
+- Install Docker
+    - [Docker for Mac](https://www.docker.com/products/docker#/mac) (or windows if you're into that sort thing)
+    - Alternatively on Mac; `brew cask install docker`>
 
 Services
 --------
 This will set up a full development environment in docker with the following services:
 
-- Cloud9 IDE (localhost:8181)
-- Ungit Git Client (localhost:8448)
 - MongoDB
 - Redis
 - RabbitMQ
-- Elasticsearch
 
 Good-to-Know Docker Compose Commands
 ------------------------------------
-- docker-compose up: Start all the services in the docker-compose environment (create if it doesn't exist).
-- docker-compose stop: Stop all the services in the docker-compose environment
-- docker-compose down: Stop and *remove* all the services (this will wipe the data too)
-
-Some Cloud9 Tips
-----------------
-- Open a new terminal with `alt-t`
-- Run `npm i -g c9` to be able to open files in Cloud9 from a terminal with `c9 FILENAME` (our main application repo will do this for you)
+- `docker-compose up`: Start all the services in the docker-compose environment (create if it doesn't exist).
+- `docker-compose stop`: Stop all the services in the docker-compose environment
+- `docker-compose down`: Stop and *remove* all the services (this will wipe the data too)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ data:
     - /data
     - /usr/src/app/data
 rabbitmq:
-  image: "rabbitmq:management"
+  image: "rabbitmq:3-management"
   hostname: rabbitmq-dev
   expose:
     - "5672"
@@ -15,7 +15,7 @@ rabbitmq:
   volumes_from:
     - data
 mongo:
-  image: "mongo:4.0.0"
+  image: "mongo:4"
   hostname: mongo-dev
   ports:
     - "27017:27017"
@@ -23,7 +23,7 @@ mongo:
     - data
   command: mongod --smallfiles
 redis:
-  image: "redis:latest"
+  image: "redis:5"
   hostname: redis-dev
   ports:
     - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,8 @@
-dev:
-  image: "busybox:latest"
-  volumes:
-# ssh is for git credentials
-    - "~/.ssh:/root/.ssh"
-# gitconfig is for git name, email, etx
-    - "~/.gitconfig:/root/.gitconfig"
-# where repos will live, which is not mapped to the host due to much slower io which makes running gulp tasks unusable slow (e.g. 30 + second commit times)
-    - "/workspace/code"
-# just a place to put stuff on the host since the repo lives in the vm
-    - "./dev:/workspace/transfer"
-ungit:
-  image: reinblau/ungit
-  volumes_from:
-    - dev
-  ports:
-    - "8448:8448"
-  command: /usr/bin/ungit --no-launchBrowser --forcedLaunchPath=/workspace
-cloud9:
-  image: sapk/cloud9
-  volumes_from:
-    - dev
-  ports:
-    - "8181:8181"
-    - "1080:80"
-    - "1337:1337"
-    - "3000:3000"
-  environment:
-    - NODE_ENV=development
-  links:
-    - rabbitmq
-    - mongo
-    - redis
-    - elasticsearch
-  command: "--auth username:password"
 data:
   image: "busybox:latest"
   volumes:
     - /var/lib/rabbitmq
     - /data
-    - /elasticsearch/data
     - /usr/src/app/data
 rabbitmq:
   image: "rabbitmq:management"
@@ -51,7 +15,7 @@ rabbitmq:
   volumes_from:
     - data
 mongo:
-  image: "mongo:latest"
+  image: "mongo:4.0.0"
   hostname: mongo-dev
   ports:
     - "27017:27017"
@@ -66,10 +30,3 @@ redis:
   volumes_from:
     - data
   command: redis-server --appendonly yes
-elasticsearch:
-  image: "smartprocure/elasticsearch:latest"
-  hostname: elasticsearch-dev
-  ports:
-    - "9200:9200"
-  volumes_from:
-    - data


### PR DESCRIPTION
- The ungit layer isn't being hosted in Docker Hub anymore, causing a
fresh `docker-compose up` to fail
- Additionally, the Cloud9, ElasticSearch, and Ungit layers were removed
since it seems no one used them anyway.